### PR TITLE
feat: Criar rotas de cancelamento de reserva (usuario e admin)

### DIFF
--- a/prisma/migrations/20250930035204_/migration.sql
+++ b/prisma/migrations/20250930035204_/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `status` on the `Reservation` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Reservation" DROP COLUMN "status",
+ADD COLUMN     "active" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "public"."Member" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "document" TEXT,
+    "gender" TEXT NOT NULL,
+    "birthdate" DATE NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "reservationId" TEXT,
+
+    CONSTRAINT "Member_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Member_document_key" ON "public"."Member"("document");
+
+-- AddForeignKey
+ALTER TABLE "public"."Member" ADD CONSTRAINT "Member_reservationId_fkey" FOREIGN KEY ("reservationId") REFERENCES "public"."Reservation"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20250930040830_/migration.sql
+++ b/prisma/migrations/20250930040830_/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Made the column `reservationId` on table `Requests` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."Requests" DROP CONSTRAINT "Requests_reservationId_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."Requests" ALTER COLUMN "reservationId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "public"."Requests" ADD CONSTRAINT "Requests_reservationId_fkey" FOREIGN KEY ("reservationId") REFERENCES "public"."Reservation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,21 +149,22 @@ model Reservation {
   experienceId String
   startDate    DateTime?
   endDate      DateTime?
-  status       String?
   notes        String?
   createdAt    DateTime   @default(now())
   Requests     Requests[]
+  active       Boolean    @default(true)
+  members      Member[]
 }
 
 model Requests {
   id              String       @id @default(uuid())
   type            RequestType
+  description     String?
   createdAt       DateTime     @default(now())
   createdBy       User         @relation(fields: [createdByUserId], references: [id])
   createdByUserId String
-  description     String?
   reservation     Reservation? @relation(fields: [reservationId], references: [id])
-  reservationId   String?
+  reservationId   String
 }
 
 enum RequestType {
@@ -177,4 +178,17 @@ enum RequestType {
   PAYMENT_REQUESTED
   PEOPLE_SENT
   PAYMENT_SENT
+}
+
+model Member {
+  id            String       @id @default(uuid())
+  name          String
+  document      String?      @unique
+  gender        String
+  birthdate     DateTime     @db.Date
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
+  active        Boolean      @default(true)
+  Reservation   Reservation? @relation(fields: [reservationId], references: [id])
+  reservationId String?
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { ReservationService } from './reservation/reservation.service';
 import { ReservationController } from './reservation/reservation.controller';
 import { ReservationModule } from './reservation/reservation.module';
 import { ExperienceModule } from './experience/experience.module';
+import { ObfuscateModule } from './obfuscate/obfuscate.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { ExperienceModule } from './experience/experience.module';
     UserModule,
     ReservationModule,
     ExperienceModule,
+    ObfuscateModule,
   ],
   controllers: [AppController, ReservationController],
   providers: [

--- a/src/obfuscate/obfuscate.module.ts
+++ b/src/obfuscate/obfuscate.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ObfuscateService } from './obfuscate.service';
+
+@Module({
+  providers: [ObfuscateService],
+  exports: [ObfuscateService],
+})
+export class ObfuscateModule {}

--- a/src/obfuscate/obfuscate.service.ts
+++ b/src/obfuscate/obfuscate.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+
+@Injectable()
+export class ObfuscateService {
+  obfuscateField(field: string) {
+    return createHash('sha256')
+      .update(field + Date.now())
+      .digest('base64');
+  }
+}

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -1,37 +1,44 @@
-import { Body, Controller, Delete, HttpCode, HttpStatus, Param, Patch, Post } from '@nestjs/common';
+import { Body, Controller, Delete, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
 import { ReservationService } from './reservation.service';
 import { Roles } from 'src/auth/role/roles.decorator';
 import { UserType } from 'generated/prisma';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { UpdateReservationDto } from './reservation.model';
+import { User } from 'src/user/user.decorator';
+import { type CurrentUser } from 'src/auth/auth.model';
 
 @Controller('reservation')
 export class ReservationController {
   constructor(private readonly reservationService: ReservationService) {}
 
-  @Patch(':reservationId')
+  @Post(':reservationId/request')
   @HttpCode(HttpStatus.NO_CONTENT)
   @Roles(UserType.ADMIN)
   @ApiBearerAuth('access-token')
-  async updateReservationAsAdmin(
+  async createRequestAdmin(
+    @User() user: CurrentUser,
     @Param('reservationId') reservationId: string,
     @Body() updateReservationDto: UpdateReservationDto,
   ) {
-    await this.reservationService.updateReservation(reservationId, updateReservationDto);
+    await this.reservationService.createRequestAdmin(reservationId, updateReservationDto, user.id);
   }
 
-  @Post('/cancelReservation/:reservationId')
+  @Post(':reservationId/request/cancel')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @Roles(UserType.GUEST)
   @ApiBearerAuth('access-token')
-  async deleteReservationAsAdmin(@Param('reservationId') reservationId: string) {
-    await this.reservationService.sendDeleteReservation(reservationId);
+  async createCancelReservationRequest(
+    @User() user: CurrentUser,
+    @Param('reservationId') reservationId: string,
+  ) {
+    await this.reservationService.createCancelRequest(reservationId, user.id);
   }
 
-  @Delete('/cancel/:id')
+  @Delete(':reservationId')
   @HttpCode(HttpStatus.NO_CONTENT)
   @Roles(UserType.ADMIN)
   @ApiBearerAuth('access-token')
-  async deleteReservation(@Param('id') id: string) {
-    return await this.reservationService.deleteReservation(id);
+  async deleteReservation(@Param('reservationId') reservationId: string) {
+    return await this.reservationService.deleteReservation(reservationId);
   }
 }

--- a/src/reservation/reservation.model.ts
+++ b/src/reservation/reservation.model.ts
@@ -1,9 +1,10 @@
+import { RequestType } from 'generated/prisma';
 import { createZodDto } from 'nestjs-zod';
 import z from 'zod';
 
 const UpdateReservation = z.object({
-  action: z.string(),
-  text: z.string().optional(),
+  type: z.enum(Object.values(RequestType)),
+  description: z.string().optional(),
 });
 
 export class UpdateReservationDto extends createZodDto(UpdateReservation) {}

--- a/src/reservation/reservation.service.ts
+++ b/src/reservation/reservation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { DatabaseService } from 'src/database/database.service';
 import { UpdateReservationDto } from './reservation.model';
 
@@ -6,26 +6,66 @@ import { UpdateReservationDto } from './reservation.model';
 export class ReservationService {
   constructor(private readonly databaseService: DatabaseService) {}
 
-  async updateReservation(reservationId: string, updateReservationDto: UpdateReservationDto) {
-    await this.databaseService.reservation.update({
-      where: { id: reservationId },
+  async createRequestAdmin(
+    reservationId: string,
+    updateReservationDto: UpdateReservationDto,
+    userId: string,
+  ) {
+    const payload = await this.databaseService.reservation.count({
+      where: {
+        id: reservationId,
+      },
+    });
+
+    if (payload === 0) {
+      throw new NotFoundException();
+    }
+
+    await this.databaseService.requests.create({
       data: {
-        status: updateReservationDto.action,
-        notes: updateReservationDto.text,
+        description: updateReservationDto.description,
+        type: updateReservationDto.type,
+        reservationId,
+        createdByUserId: userId,
       },
     });
   }
 
-  async sendDeleteReservation(reservationId: string): Promise<any> {
-    return await this.databaseService.reservation.update({
-      where: { id: reservationId },
-      data: { status: 'cancelamento_pendente' },
+  async createCancelRequest(reservationId: string, userId: string) {
+    const payload = await this.databaseService.reservation.count({
+      where: {
+        id: reservationId,
+        userId,
+      },
+    });
+
+    if (payload === 0) {
+      throw new NotFoundException();
+    }
+
+    await this.databaseService.requests.create({
+      data: {
+        type: 'CANCELED_REQUESTED',
+        reservationId: reservationId,
+        createdByUserId: userId,
+      },
     });
   }
 
-  async deleteReservation(reservationId: string): Promise<any> {
-    return await this.databaseService.prisma.reservation.delete({
+  async deleteReservation(reservationId: string) {
+    await this.databaseService.member.updateMany({
+      where: { reservationId },
+      data: {
+        document: null,
+        active: false,
+      },
+    });
+
+    return await this.databaseService.reservation.update({
       where: { id: reservationId },
+      data: {
+        active: false,
+      },
     });
   }
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -3,9 +3,10 @@ import { AnalyticsModule } from 'src/analytics/analytics.module';
 import { AnalyticsService } from 'src/analytics/analytics.service';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { ObfuscateModule } from 'src/obfuscate/obfuscate.module';
 
 @Module({
-  imports: [AnalyticsModule],
+  imports: [AnalyticsModule, ObfuscateModule],
   providers: [UserService, AnalyticsService],
   controllers: [UserController],
 })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -3,19 +3,16 @@ import { DatabaseService } from 'src/database/database.service';
 import z from 'zod';
 import { Prisma, UserType } from 'generated/prisma';
 import { UserSearchParamsDto, UpdateUserFormDto } from './user.model';
-import { createHash } from 'node:crypto';
+import { ObfuscateService } from 'src/obfuscate/obfuscate.service';
 
 @Injectable()
 export class UserService {
   private readonly logger = new Logger(UserService.name);
 
-  constructor(private readonly databaseService: DatabaseService) {}
-
-  private obfuscateField(field: string) {
-    return createHash('sha256')
-      .update(field + Date.now())
-      .digest('base64');
-  }
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly obfuscateService: ObfuscateService,
+  ) {}
 
   async deleteUser(userId: string) {
     this.verifyUserId(userId);
@@ -32,9 +29,9 @@ export class UserService {
     await this.databaseService.user.update({
       where: { id: userId },
       data: {
-        email: this.obfuscateField(user.email),
-        document: user.document ? this.obfuscateField(user.document) : null,
-        rg: user.rg ? this.obfuscateField(user.rg) : null,
+        email: this.obfuscateService.obfuscateField(user.email),
+        document: user.document ? this.obfuscateService.obfuscateField(user.document) : null,
+        rg: user.rg ? this.obfuscateService.obfuscateField(user.rg) : null,
         active: false,
       },
     });


### PR DESCRIPTION
# Mudanças
Criei 2 rotas: 
Uma é o usuário que acessa, onde é um post que atualiza o status da reserva para "cancelamento_pendente" (/cancelReservation/:reservationId)

Outra é a rota do admin, onde é um delete que deleta a reserva do banco de dados

## Rotas
```tsx
  @Post('/cancelReservation/:reservationId')
  @HttpCode(HttpStatus.NO_CONTENT)
  @ApiBearerAuth('access-token')
  async deleteReservationAsAdmin(@Param('reservationId') reservationId: string) {
    await this.reservationService.sendDeleteReservation(reservationId);
  }

  @Delete('/cancel/:id')
  @HttpCode(HttpStatus.NO_CONTENT)
  @Roles(UserType.ADMIN)
  @ApiBearerAuth('access-token')
  async deleteReservation(@Param('id') id: string) {
    return await this.reservationService.deleteReservation(id);
  }
```
## Funções
```tsx
  async sendDeleteReservation(reservationId: string): Promise<any> {
    return await this.databaseService.reservation.update({
      where: { id: reservationId },
      data: { status: 'cancelamento_pendente' },
    });
  }

  async deleteReservation(reservationId: string): Promise<any> {
    return await this.databaseService.prisma.reservation.delete({
      where: { id: reservationId },
    });
  }
```

## Acceptance Criteria
- [ ] Receber o id da reserva e criar uma solicitação de cancelamento para o admin (update do status da reserva)
- [ ] Ter outra rota específica para admin que será de cancelamento real da reserva

## Observações
Tem alguns erros porque o banco está incompleto